### PR TITLE
bump latest elixir and otp

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -9,8 +9,8 @@ jobs:
 
     strategy:
       matrix:
-        otp: [23.1.1, 24.2]
-        elixir: [1.12.2, 1.13.2]
+        otp: [24.2, 25.2]
+        elixir: [1.13.2, 1.14.3]
 
     steps:
       - uses: actions/checkout@v3.1.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.13.2-otp-24
-erlang 24.2
+elixir 1.14.3-otp-25
+erlang 25.2

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule LaunchDarklyAPI.MixProject do
     [
       app: :launch_darkly_api,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [


### PR DESCRIPTION
Dropping elixir 1.12 from supported matrix